### PR TITLE
Arbitrary pdf docinfo entry support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: xmpdf
 Type: Package
 Title: Edit 'XMP' Metadata and 'PDF' Bookmarks and Documentation Info
-Version: 0.3.0-1
+Version: 0.3.0-2
 Description: Edit 'XMP' metadata <https://en.wikipedia.org/wiki/Extensible_Metadata_Platform>
     in a variety of media file formats as well as
     edit bookmarks (aka outline aka table of contents) and documentation info entries in 'pdf' files.

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,13 @@ New features
 * New `get_bookmarks_augmented()` which augments `get_bookmarks_pdftk()`'s support
   for bookmark page numbers with `get_bookmarks_pdftools()`'s new support for
   whether bookmarks should start open or closed (#62).
+* `docinfo()` objects now support arbitrary (non-standard) info dictionary entries (#7).
+  Read/write support among the various backends is as follows:
+
+  * `get_docinfo_pdftk()`/`set_docinfo_pdftk()` support reading and writing them.
+  * `get_docinfo_exiftool()`/`set_docinfo_exiftool()` support reading and writing them.
+  * `get_docinfo_pdftools()` supports reading them.
+  * `set_docinfo_gs()` supports writing them.
 
 Bug fixes and minor improvements
 --------------------------------

--- a/R/docinfo.R
+++ b/R/docinfo.R
@@ -398,6 +398,9 @@ DocInfo <- R6Class(
 			if (!is.null(self$mod_date)) {
 				tags <- append(tags, sprintf(" /ModDate (%s)\n", to_date_pdfmark(self$mod_date)))
 			}
+			for (key in names(private$val$arbitrary)) {
+				tags <- append(tags, sprintf(" /%s (%s)\n", key, private$val$arbitrary[[key]]))
+			}
 			tags <- append(tags, " /DOCINFO pdfmark\n")
 			stri_join(tags, collapse = "")
 		},
@@ -432,6 +435,12 @@ DocInfo <- R6Class(
 			if (!is.null(self$mod_date)) {
 				mod_date <- sprintf(" /ModDate (%s)\n", to_date_pdfmark(self$mod_date))
 				tags <- append(tags, iconv(mod_date, to = "latin1", toRaw = TRUE)[[1]])
+			}
+			for (key in names(private$val$arbitrary)) {
+				tags <- append(
+					tags,
+					raw_pdfmark_entry(sprintf(" /%s (", key), private$val$arbitrary[[key]], ")\n")
+				)
 			}
 			tags <- append(tags, iconv(" /DOCINFO pdfmark\n", to = "latin1", toRaw = TRUE)[[1]])
 			tags

--- a/R/docinfo.R
+++ b/R/docinfo.R
@@ -5,6 +5,8 @@
 #' `docinfo()` creates a PDF documentation info dictionary object.
 #' Such objects can be used with [set_docinfo()] to edit PDF documentation info dictionary entries
 #' and such objects are returned by [get_docinfo()].
+#' @param ... Arbitrary (non-standard) info dictionary entries.  The names are the info dictionary key names
+#'            and the values (which should be strings) are the info dictionary values.
 #' @param author The document's author.  Matching xmp metadata tag is `dc:creator`.
 #' @param creation_date The date the document was created.
 #'                Will be coerced by [datetimeoffset::as_datetimeoffset()].
@@ -72,6 +74,7 @@
 #' }
 #' @export
 docinfo <- function(
+	...,
 	author = NULL,
 	creation_date = NULL,
 	creator = NULL,
@@ -82,6 +85,7 @@ docinfo <- function(
 	mod_date = NULL
 ) {
 	DocInfo$new(
+		...,
 		author = author,
 		creation_date = creation_date,
 		creator = creator,
@@ -96,39 +100,13 @@ docinfo <- function(
 DocInfo <- R6Class(
 	"docinfo",
 	public = list(
-		initialize = function(
-			author = NULL,
-			creation_date = NULL,
-			creator = NULL,
-			producer = NULL,
-			title = NULL,
-			subject = NULL,
-			keywords = NULL,
-			mod_date = NULL
-		) {
-			if (!is.null(author)) {
-				self$author <- author
-			}
-			if (!is.null(creation_date)) {
-				self$creation_date <- creation_date
-			}
-			if (!is.null(creator)) {
-				self$creator <- creator
-			}
-			if (!is.null(producer)) {
-				self$producer <- producer
-			}
-			if (!is.null(title)) {
-				self$title <- title
-			}
-			if (!is.null(subject)) {
-				self$subject <- subject
-			}
-			if (!is.null(keywords)) {
-				self$keywords <- keywords
-			}
-			if (!is.null(mod_date)) {
-				self$mod_date <- mod_date
+		initialize = function(...) {
+			l <- list(...)
+			for (key in names(l)) {
+				value <- l[[key]]
+				if (!is.null(value)) {
+					self$set_item(key, value)
+				}
 			}
 			invisible(NULL)
 		},
@@ -143,6 +121,9 @@ DocInfo <- R6Class(
 				stri_join("Keywords: ", d_format(self$keywords)),
 				stri_join("ModDate: ", d_format(self$mod_date))
 			)
+			for (key in names(private$val$arbitrary)) {
+				text <- append(text, stri_join(key, ": ", d_format(private$val$arbitrary[[key]])))
+			}
 			invisible(cat(text, sep = "\n"))
 		},
 		get_item = function(key) {
@@ -163,8 +144,7 @@ DocInfo <- R6Class(
 			} else if (key %in% c("mod_date", "ModDate")) {
 				self$mod_date
 			} else {
-				msg <- sprintf("We don't support key '%s' yet.", key)
-				abort(msg)
+				private$val$arbitrary[[key]]
 			}
 		},
 		set_item = function(key, value) {
@@ -185,8 +165,7 @@ DocInfo <- R6Class(
 			} else if (key %in% c("mod_date", "ModDate")) {
 				self$mod_date <- value
 			} else {
-				msg <- sprintf("We don't support key '%s' yet.", key)
-				abort(msg)
+				private$val$arbitrary[[key]] <- value
 			}
 		},
 		update = function(x) {
@@ -222,6 +201,7 @@ DocInfo <- R6Class(
 			if (!is.null(self$mod_date)) {
 				keys <- append(keys, "ModDate")
 			}
+			keys <- append(keys, names(private$val$arbitrary))
 			keys
 		},
 		exiftool_tags = function() {
@@ -383,7 +363,7 @@ DocInfo <- R6Class(
 		}
 	),
 	private = list(
-		val = list(),
+		val = list(arbitrary = list()),
 		pdfmark_character = function() {
 			tags <- "["
 			if (!is.null(self$author)) {
@@ -483,6 +463,19 @@ as.list.docinfo <- function(x, ...) {
 	}
 	if (!is.null(x$mod_date)) {
 		l$mod_date <- x$mod_date
+	}
+	known_keys <- c(
+		"Author",
+		"CreationDate",
+		"Creator",
+		"Producer",
+		"Title",
+		"Subject",
+		"Keywords",
+		"ModDate"
+	)
+	for (key in setdiff(x$get_nonnull_keys(), known_keys)) {
+		l[[key]] <- x$get_item(key)
 	}
 	l
 }

--- a/R/docinfo.R
+++ b/R/docinfo.R
@@ -5,8 +5,6 @@
 #' `docinfo()` creates a PDF documentation info dictionary object.
 #' Such objects can be used with [set_docinfo()] to edit PDF documentation info dictionary entries
 #' and such objects are returned by [get_docinfo()].
-#' @param ... Arbitrary (non-standard) info dictionary entries.  The names are the info dictionary key names
-#'            and the values (which should be strings) are the info dictionary values.
 #' @param author The document's author.  Matching xmp metadata tag is `dc:creator`.
 #' @param creation_date The date the document was created.
 #'                Will be coerced by [datetimeoffset::as_datetimeoffset()].
@@ -23,6 +21,8 @@
 #' @param mod_date The date the document was last modified.
 #'                 Will be coerced by [datetimeoffset::as_datetimeoffset()].
 #'                 Matching xmp metadata tag is `xmp:ModifyDate`.
+#' @param ... Arbitrary (non-standard) info dictionary entries.  The names are the info dictionary key names
+#'            and the values (which should be strings) are the info dictionary values.
 #' @seealso [get_docinfo()] and [set_docinfo()] for getting/setting such information from/to PDF files.
 #'          [as_docinfo()] for coercing to this object.
 #'    [as_xmp()] can be used to coerce `docinfo()` objects into [xmp()] objects.
@@ -73,7 +73,6 @@
 #' }
 #' @export
 docinfo <- function(
-	...,
 	author = NULL,
 	creation_date = NULL,
 	creator = NULL,
@@ -81,10 +80,10 @@ docinfo <- function(
 	title = NULL,
 	subject = NULL,
 	keywords = NULL,
-	mod_date = NULL
+	mod_date = NULL,
+	...
 ) {
 	DocInfo$new(
-		...,
 		author = author,
 		creation_date = creation_date,
 		creator = creator,
@@ -92,7 +91,8 @@ docinfo <- function(
 		title = title,
 		subject = subject,
 		keywords = keywords,
-		mod_date = mod_date
+		mod_date = mod_date,
+		...
 	)
 }
 
@@ -232,7 +232,7 @@ DocInfo <- R6Class(
 			if (!is.null(self$mod_date)) {
 				tags[["PDF:ModifyDate"]] <- to_date_pdfmark_exiftool(self$mod_date)
 			}
-			for (key in names(private$val$arbitrary)) {
+			for (key in private$validated_arbitrary_keys()) {
 				tags[[stri_join("PDF:", key)]] <- private$val$arbitrary[[key]]
 			}
 			tags
@@ -273,7 +273,7 @@ DocInfo <- R6Class(
 			if (!is.null(self$mod_date)) {
 				tags <- append(tags, entry_pdftk("ModDate", to_date_pdfmark(self$mod_date)))
 			}
-			for (key in names(private$val$arbitrary)) {
+			for (key in private$validated_arbitrary_keys()) {
 				tags <- append(tags, entry_pdftk(key, private$val$arbitrary[[key]]))
 			}
 			tags
@@ -404,7 +404,7 @@ DocInfo <- R6Class(
 			if (!is.null(self$mod_date)) {
 				tags <- append(tags, sprintf(" /ModDate (%s)\n", to_date_pdfmark(self$mod_date)))
 			}
-			for (key in names(private$val$arbitrary)) {
+			for (key in private$validated_arbitrary_keys()) {
 				tags <- append(tags, sprintf(" /%s (%s)\n", key, private$val$arbitrary[[key]]))
 			}
 			tags <- append(tags, " /DOCINFO pdfmark\n")
@@ -442,7 +442,7 @@ DocInfo <- R6Class(
 				mod_date <- sprintf(" /ModDate (%s)\n", to_date_pdfmark(self$mod_date))
 				tags <- append(tags, iconv(mod_date, to = "latin1", toRaw = TRUE)[[1]])
 			}
-			for (key in names(private$val$arbitrary)) {
+			for (key in private$validated_arbitrary_keys()) {
 				tags <- append(
 					tags,
 					raw_pdfmark_entry(sprintf(" /%s (", key), private$val$arbitrary[[key]], ")\n")
@@ -450,6 +450,13 @@ DocInfo <- R6Class(
 			}
 			tags <- append(tags, iconv(" /DOCINFO pdfmark\n", to = "latin1", toRaw = TRUE)[[1]])
 			tags
+		},
+		validated_arbitrary_keys = function() {
+			keys <- names(private$val$arbitrary)
+			for (key in keys) {
+				assert_valid_docinfo_key(key)
+			}
+			keys
 		}
 	)
 )
@@ -481,7 +488,15 @@ as.list.docinfo <- function(x, ...) {
 	if (!is.null(x$mod_date)) {
 		l$mod_date <- x$mod_date
 	}
-	known_keys <- c(
+	for (key in setdiff(x$get_nonnull_keys(), docinfo_known_keys())) {
+		l[[key]] <- x$get_item(key)
+	}
+	l
+}
+
+# The standard (non-arbitrary) PDF Info dictionary key names
+docinfo_known_keys <- function() {
+	c(
 		"Author",
 		"CreationDate",
 		"Creator",
@@ -491,10 +506,17 @@ as.list.docinfo <- function(x, ...) {
 		"Keywords",
 		"ModDate"
 	)
-	for (key in setdiff(x$get_nonnull_keys(), known_keys)) {
-		l[[key]] <- x$get_item(key)
+}
+
+# Arbitrary info dictionary keys are written as literal PDF names / exiftool tag names
+# by the various backends, so restrict them to a safe, portable character set.
+assert_valid_docinfo_key <- function(key) {
+	if (!grepl("^[A-Za-z][A-Za-z0-9_]*$", key)) {
+		abort(c(
+			sprintf("Invalid (arbitrary) info dictionary key: %s", sQuote(key)),
+			"i" = "Keys must start with a letter and contain only letters, digits, and underscores."
+		))
 	}
-	l
 }
 
 #' @export

--- a/R/docinfo.R
+++ b/R/docinfo.R
@@ -203,6 +203,9 @@ DocInfo <- R6Class(
 			keys <- append(keys, names(private$val$arbitrary))
 			keys
 		},
+		arbitrary_keys = function() {
+			names(private$val$arbitrary)
+		},
 		exiftool_tags = function() {
 			tags <- list()
 			if (!is.null(self$author)) {
@@ -228,6 +231,9 @@ DocInfo <- R6Class(
 			}
 			if (!is.null(self$mod_date)) {
 				tags[["PDF:ModifyDate"]] <- to_date_pdfmark_exiftool(self$mod_date)
+			}
+			for (key in names(private$val$arbitrary)) {
+				tags[[stri_join("PDF:", key)]] <- private$val$arbitrary[[key]]
 			}
 			tags
 		},

--- a/R/docinfo.R
+++ b/R/docinfo.R
@@ -26,10 +26,9 @@
 #' @seealso [get_docinfo()] and [set_docinfo()] for getting/setting such information from/to PDF files.
 #'          [as_docinfo()] for coercing to this object.
 #'    [as_xmp()] can be used to coerce `docinfo()` objects into [xmp()] objects.
-#' @section Known limitations:
-#'
-#'   * Currently does not support arbitrary info dictionary entries.
-#'
+#'    See [edit_docinfo()] for known limitations regarding arbitrary (non-standard)
+#'    info dictionary entry support across the different get/set backends.
+
 #' @section `docinfo` R6 Class Methods:\describe{
 #'     \item{`get_item(key)`}{Get documentation info value for key `key`.
 #'           Can also use the relevant active bindings to get documentation info values.}
@@ -267,6 +266,9 @@ DocInfo <- R6Class(
 			}
 			if (!is.null(self$mod_date)) {
 				tags <- append(tags, entry_pdftk("ModDate", to_date_pdfmark(self$mod_date)))
+			}
+			for (key in names(private$val$arbitrary)) {
+				tags <- append(tags, entry_pdftk(key, private$val$arbitrary[[key]]))
 			}
 			tags
 		},

--- a/R/edit_docinfo.R
+++ b/R/edit_docinfo.R
@@ -27,8 +27,8 @@
 #'         `set_docinfo()` returns the (output) filename invisibly.
 #' @section Known limitations:
 #'
-#'   * `get_docinfo_pdftk()`/`set_docinfo_pdftk()` support arbitrary (non-standard) info dictionary entries.
-#'     `get_docinfo_exiftool()`/`get_docinfo_pdftools()`/`set_docinfo_gs()`/`set_docinfo_exiftool()`
+#'   * `get_docinfo_pdftk()`/`set_docinfo_pdftk()` and `set_docinfo_gs()` support arbitrary (non-standard)
+#'     info dictionary entries.  `get_docinfo_exiftool()`/`get_docinfo_pdftools()`/`set_docinfo_exiftool()`
 #'     don't support them yet.
 #'   * As a side effect `set_docinfo_gs()` seems to also update in previously set matching XPN metadata
 #'     while `set_docinfo_exiftool()` and `set_docinfo_pdftk()` don't update

--- a/R/edit_docinfo.R
+++ b/R/edit_docinfo.R
@@ -94,8 +94,9 @@ get_docinfo_pdftools <- function(filename, use_names = TRUE) {
 get_docinfo_pdftools_helper <- function(filename) {
 	info <- pdftools::pdf_info(filename)
 	dinfo <- docinfo()
-	for (i in seq_along(info$keys)) {
-		dinfo$set_item(names(info$keys)[i], info$keys[[i]])
+	skip_keys <- c("CreationDate", "ModDate")
+	for (key in setdiff(names(info$keys), skip_keys)) {
+		dinfo$set_item(key, info$keys[[key]])
 	}
 	if (!is.null(info$created)) {
 		dinfo$creation_date <- info$created
@@ -153,47 +154,37 @@ get_docinfo_pdftk <- function(filename, use_names = TRUE) {
 get_docinfo_pdftk_helper <- function(filename) {
 	info <- get_pdftk_metadata(filename)
 	dinfo <- docinfo()
-	if (length(id <- grep("^InfoKey: Author", info))) {
+	if (length(id <- grep("^InfoKey: Author$", info))) {
 		dinfo$author <- pdftk_string_value(info, id)
 	}
-	if (length(id <- grep("^InfoKey: CreationDate", info))) {
+	if (length(id <- grep("^InfoKey: CreationDate$", info))) {
 		dinfo$creation_date <- datetimeoffset::as_datetimeoffset(gsub(
 			"^InfoValue: ",
 			"",
 			info[id + 1]
 		))
 	}
-	if (length(id <- grep("^InfoKey: Creator", info))) {
+	if (length(id <- grep("^InfoKey: Creator$", info))) {
 		dinfo$creator <- pdftk_string_value(info, id)
 	}
-	if (length(id <- grep("^InfoKey: Producer", info))) {
+	if (length(id <- grep("^InfoKey: Producer$", info))) {
 		dinfo$producer <- pdftk_string_value(info, id)
 	}
-	if (length(id <- grep("^InfoKey: Title", info))) {
+	if (length(id <- grep("^InfoKey: Title$", info))) {
 		dinfo$title <- pdftk_string_value(info, id)
 	}
-	if (length(id <- grep("^InfoKey: Subject", info))) {
+	if (length(id <- grep("^InfoKey: Subject$", info))) {
 		dinfo$subject <- pdftk_string_value(info, id)
 	}
-	if (length(id <- grep("^InfoKey: Keywords", info))) {
+	if (length(id <- grep("^InfoKey: Keywords$", info))) {
 		dinfo$keywords <- pdftk_string_value(info, id)
 	}
-	if (length(id <- grep("^InfoKey: ModDate", info))) {
+	if (length(id <- grep("^InfoKey: ModDate$", info))) {
 		dinfo$mod_date <- datetimeoffset::as_datetimeoffset(gsub("^InfoValue: ", "", info[id + 1]))
 	}
-	known_keys <- c(
-		"Author",
-		"CreationDate",
-		"Creator",
-		"Producer",
-		"Title",
-		"Subject",
-		"Keywords",
-		"ModDate"
-	)
 	for (id in grep("^InfoKey: ", info)) {
 		key <- gsub("^InfoKey: ", "", info[id])
-		if (!key %in% known_keys) {
+		if (!key %in% docinfo_known_keys()) {
 			dinfo$set_item(key, pdftk_string_value(info, id))
 		}
 	}

--- a/R/edit_docinfo.R
+++ b/R/edit_docinfo.R
@@ -27,9 +27,9 @@
 #'         `set_docinfo()` returns the (output) filename invisibly.
 #' @section Known limitations:
 #'
-#'   * `get_docinfo_pdftk()`/`set_docinfo_pdftk()` and `set_docinfo_gs()` support arbitrary (non-standard)
-#'     info dictionary entries.  `get_docinfo_exiftool()`/`get_docinfo_pdftools()`/`set_docinfo_exiftool()`
-#'     don't support them yet.
+#'   * `get_docinfo_pdftk()`/`set_docinfo_pdftk()`, `get_docinfo_pdftools()`, and `set_docinfo_gs()`
+#'     support arbitrary (non-standard) info dictionary entries.
+#'     `get_docinfo_exiftool()`/`set_docinfo_exiftool()` don't support them yet.
 #'   * As a side effect `set_docinfo_gs()` seems to also update in previously set matching XPN metadata
 #'     while `set_docinfo_exiftool()` and `set_docinfo_pdftk()` don't update
 #'     any previously set matching XPN metadata.
@@ -98,13 +98,7 @@ get_docinfo_pdftools_helper <- function(filename) {
 	info <- pdftools::pdf_info(filename)
 	dinfo <- docinfo()
 	for (i in seq_along(info$keys)) {
-		key <- names(info$keys)[i]
-		if (key %in% c("Author", "Creator", "Producer", "Title", "Subject", "Keywords")) {
-			dinfo$set_item(names(info$keys)[i], info$keys[[i]])
-		} else {
-			msg <- sprintf("We don't support key '%s' yet.", key)
-			warn(msg)
-		}
+		dinfo$set_item(names(info$keys)[i], info$keys[[i]])
 	}
 	if (!is.null(info$created)) {
 		dinfo$creation_date <- info$created

--- a/R/edit_docinfo.R
+++ b/R/edit_docinfo.R
@@ -27,10 +27,7 @@
 #'         `set_docinfo()` returns the (output) filename invisibly.
 #' @section Known limitations:
 #'
-#'   * `get_docinfo_pdftk()`/`set_docinfo_pdftk()`, `get_docinfo_pdftools()`, and `set_docinfo_gs()`
-#'     support arbitrary (non-standard) info dictionary entries.
-#'     `get_docinfo_exiftool()`/`set_docinfo_exiftool()` don't support them yet.
-#'   * As a side effect `set_docinfo_gs()` seems to also update in previously set matching XPN metadata
+#'   * As a side effect `set_docinfo_gs()` seems to also update previously set matching XPN metadata
 #'     while `set_docinfo_exiftool()` and `set_docinfo_pdftk()` don't update
 #'     any previously set matching XPN metadata.
 #'     Some pdf viewers will preferentially use the previously set document title from XPN metadata
@@ -121,18 +118,9 @@ get_docinfo_exiftool_helper <- function(filename) {
 	names(md) <- gsub("^PDF:", "", names(md))
 	dinfo <- docinfo()
 
-	for (i in seq_along(md)) {
-		key <- names(md)[i]
-		if (key %in% c("Author", "Creator", "Producer", "Title", "Subject", "Keywords")) {
-			dinfo$set_item(names(md)[i], md[[i]])
-		} else if (
-			key %in% c("PDFVersion", "Linearized", "PageCount", "CreateDate", "ModifyDate")
-		) {
-			next
-		} else {
-			msg <- sprintf("We don't support key '%s' yet.", key)
-			warn(msg)
-		}
+	skip_keys <- c("PDFVersion", "Linearized", "PageCount", "CreateDate", "ModifyDate")
+	for (key in setdiff(names(md), skip_keys)) {
+		dinfo$set_item(key, md[[key]])
 	}
 	if (!is.null(md$CreateDate)) {
 		dinfo$creation_date <- md$CreateDate
@@ -148,7 +136,11 @@ get_docinfo_exiftool_helper <- function(filename) {
 set_docinfo_exiftool <- function(docinfo, input, output = input) {
 	docinfo <- as_docinfo(docinfo)
 	tags <- docinfo$exiftool_tags()
-	set_exiftool_metadata(tags, input, output, mode = "pdf")
+	config <- exiftool_config_pdf_info(docinfo$arbitrary_keys())
+	if (!is.null(config)) {
+		on.exit(unlink(config), add = TRUE)
+	}
+	set_exiftool_metadata(tags, input, output, mode = "pdf", config = config)
 }
 
 #' @rdname edit_docinfo

--- a/R/edit_docinfo.R
+++ b/R/edit_docinfo.R
@@ -27,7 +27,9 @@
 #'         `set_docinfo()` returns the (output) filename invisibly.
 #' @section Known limitations:
 #'
-#'   * Currently does not support arbitrary info dictionary entries.
+#'   * `get_docinfo_pdftk()`/`set_docinfo_pdftk()` support arbitrary (non-standard) info dictionary entries.
+#'     `get_docinfo_exiftool()`/`get_docinfo_pdftools()`/`set_docinfo_gs()`/`set_docinfo_exiftool()`
+#'     don't support them yet.
 #'   * As a side effect `set_docinfo_gs()` seems to also update in previously set matching XPN metadata
 #'     while `set_docinfo_exiftool()` and `set_docinfo_pdftk()` don't update
 #'     any previously set matching XPN metadata.
@@ -192,6 +194,22 @@ get_docinfo_pdftk_helper <- function(filename) {
 	}
 	if (length(id <- grep("^InfoKey: ModDate", info))) {
 		dinfo$mod_date <- datetimeoffset::as_datetimeoffset(gsub("^InfoValue: ", "", info[id + 1]))
+	}
+	known_keys <- c(
+		"Author",
+		"CreationDate",
+		"Creator",
+		"Producer",
+		"Title",
+		"Subject",
+		"Keywords",
+		"ModDate"
+	)
+	for (id in grep("^InfoKey: ", info)) {
+		key <- gsub("^InfoKey: ", "", info[id])
+		if (!key %in% known_keys) {
+			dinfo$set_item(key, pdftk_string_value(info, id))
+		}
 	}
 	dinfo
 }

--- a/R/utils-exiftool.R
+++ b/R/utils-exiftool.R
@@ -61,8 +61,9 @@ as_exif_name <- function(x, name) {
 }
 
 #' @param tags Named list of metadata tags to set
+#' @param config Optional path to an `exiftool` `-config` file declaring any custom/arbitrary tags in `tags`.
 #' @noRd
-set_exiftool_metadata <- function(tags, input, output = input, mode = "xmp") {
+set_exiftool_metadata <- function(tags, input, output = input, mode = "xmp", config = NULL) {
 	stopifnot(supports_exiftool())
 	input <- normalizePath(input, mustWork = TRUE)
 	output <- normalizePath(output, mustWork = FALSE)
@@ -100,6 +101,11 @@ set_exiftool_metadata <- function(tags, input, output = input, mode = "xmp") {
 	on.exit(unlink(f), add = TRUE)
 	brio::write_lines(args, f)
 	args <- c("-@", shQuote(f))
+	# `-config` must be the literal first option on the command line, not merely
+	# first inside the `-@` argfile, or `exiftool` ignores it.
+	if (!is.null(config)) {
+		args <- c("-config", shQuote(config), args)
+	}
 	if (length(cmd) == 2L) {
 		# i.e. c("/path/to/perl", "path/to/exiftool")
 		args <- c(cmd[-1L], args)
@@ -110,4 +116,29 @@ set_exiftool_metadata <- function(tags, input, output = input, mode = "xmp") {
 		file.copy(target, output, overwrite = TRUE)
 	}
 	invisible(output)
+}
+
+# Generate a temp `exiftool` `-config` file declaring `keys` as writable string tags
+# in the classic PDF Info dictionary.  Returns `NULL` if `keys` is empty.
+exiftool_config_pdf_info <- function(keys) {
+	if (!length(keys)) {
+		return(NULL)
+	}
+	entries <- stri_join("        '", escape_perl_string(keys), "' => { Writable => 'string' },")
+	lines <- c(
+		"%Image::ExifTool::UserDefined = (",
+		"    'Image::ExifTool::PDF::Info' => {",
+		entries,
+		"    },",
+		");",
+		"1;"
+	)
+	f <- tempfile(fileext = ".pl")
+	brio::write_lines(lines, f)
+	f
+}
+
+escape_perl_string <- function(x) {
+	x <- gsub("\\", "\\\\", x, fixed = TRUE)
+	gsub("'", "\\'", x, fixed = TRUE)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -44,19 +44,19 @@ Depending on what you'd like to do you'll need to install some additional R pack
 
 * **[exiftool](https://exiftool.org/)** can be used to get/set xmp metadata in a variety of media files as well as documentation info entries in pdf files.  Can also be used to get the number of pages in a pdf.  Note can be installed by [{exiftoolr}](https://github.com/JoshOBrien/exiftoolr).
 
-  + `install.packages("exiftoolr"); exiftoolr::install_exiftool()` (Cross-Platform) 
+  + `install.packages("exiftoolr"); exiftoolr::install_exiftool()` (Cross-Platform)
   + `sudo apt-get install libimage-exiftool-perl` (Debian/Ubuntu)
   + `brew install exiftool` (Homebrew)
   + `choco install exiftool` (Chocolately)
 
-* **[ghostscript](https://www.ghostscript.com/)** can be used to set bookmarks and documentation info entries in pdf files. 
+* **[ghostscript](https://www.ghostscript.com/)** can be used to set bookmarks and documentation info entries in pdf files.
   Can also be used to concatenate pdf files together as well as get the number of pages in a pdf.
 
   + `sudo apt-get install ghostscript` (Debian/Ubuntu)
   + `brew install ghostscript` (Homebrew)
   + `choco install ghostscript` (Chocolately)
 
-* **[pdftk-java](https://gitlab.com/pdftk-java/pdftk)** or perhaps **[pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/)** can be used to get/set bookmarks and documentation info entries in pdf files.  
+* **[pdftk-java](https://gitlab.com/pdftk-java/pdftk)** or perhaps **[pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/)** can be used to get/set bookmarks and documentation info entries in pdf files.
   Can also be used to concatenate pdf files together as well as get the number of pages in a pdf.
 
   + `sudo apt-get install pdftk-java` (Debian/Ubuntu)
@@ -200,14 +200,13 @@ Known limitations:
 * `set_bookmarks_pdftk()` only supports setting the title, page number, and level of bookmarks.
 * `set_docinfo_pdftk()` may not handle entries with newlines in them.
 * `set_bookmarks_pdftk()` and `set_docinfo_pdftk()` may not successfully write Unicode metadata in a non-Unicode locale.
-* All of the `set_docinfo()` methods currently do not support arbitrary info dictionary entries.
 * As a side effect `set_docinfo_gs()` seems to also update any matching XPN metadata
   while `set_docinfo_exiftool()` and `set_docinfo_pdftk()` don't update
   any previously set matching XPN metadata.
   Some pdf viewers will preferentially use the previously set document title from XPN metadata
   if it exists instead of using the title set in documentation info dictionary entry.
-  Consider also manually setting this XPN metadata using `set_xmp()` 
-* Old metadata information is usually not deleted from the files by these 
+  Consider also manually setting this XPN metadata using `set_xmp()`
+* Old metadata information is usually not deleted from the files by these
   operations (i.e. these operations are often theoretically reversible).
   If deleting the old metadata is important one may want to consider calling
   `qpdf::pdf_compress(input, linearize = TRUE)` at the end.
@@ -235,10 +234,10 @@ Please feel free to [open a pull request to add any missing relevant R packages]
 
 #### exiftool
 
-* [{exifr}](https://github.com/paleolimbot/exifr) 
+* [{exifr}](https://github.com/paleolimbot/exifr)
   provides a high-level wrapper to read metadata as well as a low-level wrapper around the `exiftool` command-line tool.
   Can download `exiftool`.
-* [{exiftoolr}](https://github.com/JoshOBrien/exiftoolr) 
+* [{exiftoolr}](https://github.com/JoshOBrien/exiftoolr)
   provides high-level wrapper to read metadata as well as a low-level wrapper around the `exiftool` command-line tool.
   Can download `exiftool`.
 * [exiftool](https://exiftool.org/)

--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ Depending on what you'd like to do you'll need to install some additional R pack
 
 * **[exiftool](https://exiftool.org/)** can be used to get/set xmp metadata in a variety of media files as well as documentation info entries in pdf files.  Can also be used to get the number of pages in a pdf.  Note can be installed by [{exiftoolr}](https://github.com/JoshOBrien/exiftoolr).
 
-  + `install.packages("exiftoolr"); exiftoolr::install_exiftool()` (Cross-Platform) 
+  + `install.packages("exiftoolr"); exiftoolr::install_exiftool()` (Cross-Platform)
   + `sudo apt-get install libimage-exiftool-perl` (Debian/Ubuntu)
   + `brew install exiftool` (Homebrew)
   + `choco install exiftool` (Chocolately)
 
-* **[ghostscript](https://www.ghostscript.com/)** can be used to set bookmarks and documentation info entries in pdf files. 
+* **[ghostscript](https://www.ghostscript.com/)** can be used to set bookmarks and documentation info entries in pdf files.
   Can also be used to concatenate pdf files together as well as get the number of pages in a pdf.
 
   + `sudo apt-get install ghostscript` (Debian/Ubuntu)
   + `brew install ghostscript` (Homebrew)
   + `choco install ghostscript` (Chocolately)
 
-* **[pdftk-java](https://gitlab.com/pdftk-java/pdftk)** or perhaps **[pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/)** can be used to get/set bookmarks and documentation info entries in pdf files.  
+* **[pdftk-java](https://gitlab.com/pdftk-java/pdftk)** or perhaps **[pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/)** can be used to get/set bookmarks and documentation info entries in pdf files.
   Can also be used to concatenate pdf files together as well as get the number of pages in a pdf.
 
   + `sudo apt-get install pdftk-java` (Debian/Ubuntu)
@@ -328,14 +328,13 @@ Known limitations:
 * `set_bookmarks_gs()` supports most bookmarks features including color and font face but only action supported is to view a particular page.
 * `set_bookmarks_pdftk()` only supports setting the title, page number, and level of bookmarks.
 * `set_docinfo_pdftk()` may not handle entries with newlines in them.
-* All of the `set_docinfo()` methods currently do not support arbitrary info dictionary entries.
 * As a side effect `set_docinfo_gs()` seems to also update any matching XPN metadata
   while `set_docinfo_exiftool()` and `set_docinfo_pdftk()` don't update
   any previously set matching XPN metadata.
   Some pdf viewers will preferentially use the previously set document title from XPN metadata
   if it exists instead of using the title set in documentation info dictionary entry.
-  Consider also manually setting this XPN metadata using `set_xmp()` 
-* Old metadata information is usually not deleted from the files by these 
+  Consider also manually setting this XPN metadata using `set_xmp()`
+* Old metadata information is usually not deleted from the files by these
   operations (i.e. these operations are often theoretically reversible).
   If deleting the old metadata is important one may want to consider calling
   `qpdf::pdf_compress(input, linearize = TRUE)` at the end.
@@ -363,10 +362,10 @@ Please feel free to [open a pull request to add any missing relevant R packages]
 
 #### exiftool
 
-* [{exifr}](https://github.com/paleolimbot/exifr) 
+* [{exifr}](https://github.com/paleolimbot/exifr)
   provides a high-level wrapper to read metadata as well as a low-level wrapper around the `exiftool` command-line tool.
   Can download `exiftool`.
-* [{exiftoolr}](https://github.com/JoshOBrien/exiftoolr) 
+* [{exiftoolr}](https://github.com/JoshOBrien/exiftoolr)
   provides high-level wrapper to read metadata as well as a low-level wrapper around the `exiftool` command-line tool.
   Can download `exiftool`.
 * [exiftool](https://exiftool.org/)

--- a/man/docinfo.Rd
+++ b/man/docinfo.Rd
@@ -5,6 +5,7 @@
 \title{PDF documentation info dictionary object}
 \usage{
 docinfo(
+  ...,
   author = NULL,
   creation_date = NULL,
   creator = NULL,
@@ -16,6 +17,9 @@ docinfo(
 )
 }
 \arguments{
+\item{...}{Arbitrary (non-standard) info dictionary entries.  The names are the info dictionary key names
+and the values (which should be strings) are the info dictionary values.}
+
 \item{author}{The document's author.  Matching xmp metadata tag is \code{dc:creator}.}
 
 \item{creation_date}{The date the document was created.
@@ -45,13 +49,6 @@ Matching xmp metadata tag is \code{xmp:ModifyDate}.}
 Such objects can be used with \code{\link[=set_docinfo]{set_docinfo()}} to edit PDF documentation info dictionary entries
 and such objects are returned by \code{\link[=get_docinfo]{get_docinfo()}}.
 }
-\section{Known limitations}{
-
-\itemize{
-\item Currently does not support arbitrary info dictionary entries.
-}
-}
-
 \section{\code{docinfo} R6 Class Methods}{
 \describe{
 \item{\code{get_item(key)}}{Get documentation info value for key \code{key}.
@@ -105,4 +102,6 @@ if (supports_set_docinfo() && supports_get_docinfo() && require("grid", quietly 
 \code{\link[=get_docinfo]{get_docinfo()}} and \code{\link[=set_docinfo]{set_docinfo()}} for getting/setting such information from/to PDF files.
 \code{\link[=as_docinfo]{as_docinfo()}} for coercing to this object.
 \code{\link[=as_xmp]{as_xmp()}} can be used to coerce \code{docinfo()} objects into \code{\link[=xmp]{xmp()}} objects.
+See \code{\link[=edit_docinfo]{edit_docinfo()}} for known limitations regarding arbitrary (non-standard)
+info dictionary entry support across the different get/set backends.
 }

--- a/man/docinfo.Rd
+++ b/man/docinfo.Rd
@@ -5,7 +5,6 @@
 \title{PDF documentation info dictionary object}
 \usage{
 docinfo(
-  ...,
   author = NULL,
   creation_date = NULL,
   creator = NULL,
@@ -13,13 +12,11 @@ docinfo(
   title = NULL,
   subject = NULL,
   keywords = NULL,
-  mod_date = NULL
+  mod_date = NULL,
+  ...
 )
 }
 \arguments{
-\item{...}{Arbitrary (non-standard) info dictionary entries.  The names are the info dictionary key names
-and the values (which should be strings) are the info dictionary values.}
-
 \item{author}{The document's author.  Matching xmp metadata tag is \code{dc:creator}.}
 
 \item{creation_date}{The date the document was created.
@@ -43,6 +40,9 @@ Will be coerced into a string by \code{stringi::stri_join(keywords, collapse = "
 \item{mod_date}{The date the document was last modified.
 Will be coerced by \code{\link[datetimeoffset:as_datetimeoffset]{datetimeoffset::as_datetimeoffset()}}.
 Matching xmp metadata tag is \code{xmp:ModifyDate}.}
+
+\item{...}{Arbitrary (non-standard) info dictionary entries.  The names are the info dictionary key names
+and the values (which should be strings) are the info dictionary values.}
 }
 \description{
 \code{docinfo()} creates a PDF documentation info dictionary object.

--- a/man/edit_docinfo.Rd
+++ b/man/edit_docinfo.Rd
@@ -66,10 +66,7 @@ set_docinfo_pdftk(docinfo, input, output = input)
 \section{Known limitations}{
 
 \itemize{
-\item \code{get_docinfo_pdftk()}/\code{set_docinfo_pdftk()}, \code{get_docinfo_pdftools()}, and \code{set_docinfo_gs()}
-support arbitrary (non-standard) info dictionary entries.
-\code{get_docinfo_exiftool()}/\code{set_docinfo_exiftool()} don't support them yet.
-\item As a side effect \code{set_docinfo_gs()} seems to also update in previously set matching XPN metadata
+\item As a side effect \code{set_docinfo_gs()} seems to also update previously set matching XPN metadata
 while \code{set_docinfo_exiftool()} and \code{set_docinfo_pdftk()} don't update
 any previously set matching XPN metadata.
 Some pdf viewers will preferentially use the previously set document title from XPN metadata

--- a/man/edit_docinfo.Rd
+++ b/man/edit_docinfo.Rd
@@ -66,7 +66,9 @@ set_docinfo_pdftk(docinfo, input, output = input)
 \section{Known limitations}{
 
 \itemize{
-\item Currently does not support arbitrary info dictionary entries.
+\item \code{get_docinfo_pdftk()}/\code{set_docinfo_pdftk()} support arbitrary (non-standard) info dictionary entries.
+\code{get_docinfo_exiftool()}/\code{get_docinfo_pdftools()}/\code{set_docinfo_gs()}/\code{set_docinfo_exiftool()}
+don't support them yet.
 \item As a side effect \code{set_docinfo_gs()} seems to also update in previously set matching XPN metadata
 while \code{set_docinfo_exiftool()} and \code{set_docinfo_pdftk()} don't update
 any previously set matching XPN metadata.

--- a/man/edit_docinfo.Rd
+++ b/man/edit_docinfo.Rd
@@ -66,8 +66,8 @@ set_docinfo_pdftk(docinfo, input, output = input)
 \section{Known limitations}{
 
 \itemize{
-\item \code{get_docinfo_pdftk()}/\code{set_docinfo_pdftk()} support arbitrary (non-standard) info dictionary entries.
-\code{get_docinfo_exiftool()}/\code{get_docinfo_pdftools()}/\code{set_docinfo_gs()}/\code{set_docinfo_exiftool()}
+\item \code{get_docinfo_pdftk()}/\code{set_docinfo_pdftk()} and \code{set_docinfo_gs()} support arbitrary (non-standard)
+info dictionary entries.  \code{get_docinfo_exiftool()}/\code{get_docinfo_pdftools()}/\code{set_docinfo_exiftool()}
 don't support them yet.
 \item As a side effect \code{set_docinfo_gs()} seems to also update in previously set matching XPN metadata
 while \code{set_docinfo_exiftool()} and \code{set_docinfo_pdftk()} don't update

--- a/man/edit_docinfo.Rd
+++ b/man/edit_docinfo.Rd
@@ -66,9 +66,9 @@ set_docinfo_pdftk(docinfo, input, output = input)
 \section{Known limitations}{
 
 \itemize{
-\item \code{get_docinfo_pdftk()}/\code{set_docinfo_pdftk()} and \code{set_docinfo_gs()} support arbitrary (non-standard)
-info dictionary entries.  \code{get_docinfo_exiftool()}/\code{get_docinfo_pdftools()}/\code{set_docinfo_exiftool()}
-don't support them yet.
+\item \code{get_docinfo_pdftk()}/\code{set_docinfo_pdftk()}, \code{get_docinfo_pdftools()}, and \code{set_docinfo_gs()}
+support arbitrary (non-standard) info dictionary entries.
+\code{get_docinfo_exiftool()}/\code{set_docinfo_exiftool()} don't support them yet.
 \item As a side effect \code{set_docinfo_gs()} seems to also update in previously set matching XPN metadata
 while \code{set_docinfo_exiftool()} and \code{set_docinfo_pdftk()} don't update
 any previously set matching XPN metadata.

--- a/tests/testthat/_snaps/docinfo.md
+++ b/tests/testthat/_snaps/docinfo.md
@@ -32,3 +32,18 @@
          xmp:CreatorTool := Generic Creator
          xmp:ModifyDate := 2022-11-11T11:11:11
 
+# docinfo() arbitrary keys
+
+    Code
+      print(d)
+    Output
+      Author: John Doe
+      CreationDate: NULL
+      Creator: NULL
+      Producer: NULL
+      Title: NULL
+      Subject: NULL
+      Keywords: NULL
+      ModDate: NULL
+      ADBETest_MyKey: My private information
+

--- a/tests/testthat/test-docinfo.R
+++ b/tests/testthat/test-docinfo.R
@@ -132,6 +132,20 @@ test_that("set_docinfo_gs", {
 	d <- get_docinfo(f4)[[1]]
 	expect_equal(d$subject, "R\u5f88\u68d2\uff01")
 	expect_equal(d$title, "Test title")
+
+	# Arbitrary (non-standard) info dictionary entries
+	di_set <- docinfo(author = "John Doe", ADBETest_MyKey = "My private information")
+	set_docinfo_gs(di_set, f1, f3)
+	di_get <- get_docinfo(f3)[[1]]
+	expect_equal(di_get$author, "John Doe")
+	expect_equal(di_get$get_item("ADBETest_MyKey"), "My private information")
+
+	# Arbitrary entry with non-Latin-1 characters
+	di_set <- docinfo()
+	di_set$set_item("CustomUnicodeKey", "R\u5f88\u68d2\uff01")
+	set_docinfo_gs(di_set, f1, f3)
+	di_get <- get_docinfo(f3)[[1]]
+	expect_equal(di_get$get_item("CustomUnicodeKey"), "R\u5f88\u68d2\uff01")
 })
 
 test_that("docinfo_exiftool", {

--- a/tests/testthat/test-docinfo.R
+++ b/tests/testthat/test-docinfo.R
@@ -205,6 +205,24 @@ test_that("conversion to/from docinfo()", {
 	expect_equal(d3$subject, "Generic Subject")
 })
 
+test_that("docinfo() arbitrary keys", {
+	d <- docinfo(author = "John Doe", ADBETest_MyKey = "My private information")
+	expect_equal(d$get_item("ADBETest_MyKey"), "My private information")
+	expect_equal(d$get_nonnull_keys(), c("Author", "ADBETest_MyKey"))
+
+	dl <- as.list(d)
+	expect_equal(dl$ADBETest_MyKey, "My private information")
+
+	expect_snapshot(print(d))
+
+	d2 <- docinfo()
+	d2$update(d)
+	expect_equal(d2$get_item("ADBETest_MyKey"), "My private information")
+
+	d$set_item("ADBETest_MyKey", "Updated information")
+	expect_equal(d$get_item("ADBETest_MyKey"), "Updated information")
+})
+
 test_that("update", {
 	d <- docinfo(author = "John Doe")
 	expect_equal(d$author, "John Doe")

--- a/tests/testthat/test-docinfo.R
+++ b/tests/testthat/test-docinfo.R
@@ -191,6 +191,20 @@ test_that("docinfo_exiftool", {
 	skip_on_os("mac") # CRAN checks on macOS 14
 	set_docinfo_exiftool(docinfo(subject = "R\u5f88\u68d2\uff01"), f4)
 	expect_equal(get_docinfo_exiftool(f4)[[1]]$subject, "R\u5f88\u68d2\uff01")
+
+	# Arbitrary (non-standard) info dictionary entries
+	di_set <- docinfo(author = "John Doe", ADBETest_MyKey = "My private information")
+	set_docinfo_exiftool(di_set, f1, f3)
+	di_get <- get_docinfo_exiftool(f3)[[1]]
+	expect_equal(di_get$author, "John Doe")
+	expect_equal(di_get$get_item("ADBETest_MyKey"), "My private information")
+
+	# Arbitrary entry with a quote/backslash (exercises `-config` escaping)
+	di_set <- docinfo()
+	di_set$set_item("WeirdKey", "value with a 'quote' and a \\backslash")
+	set_docinfo_exiftool(di_set, f1, f3)
+	di_get <- get_docinfo_exiftool(f3)[[1]]
+	expect_equal(di_get$get_item("WeirdKey"), "value with a 'quote' and a \\backslash")
 })
 
 test_that("docinfo()", {

--- a/tests/testthat/test-docinfo.R
+++ b/tests/testthat/test-docinfo.R
@@ -37,6 +37,13 @@ test_that("docinfo_pdftk", {
 	expect_equal(di_get$title, "Two Boring Pages")
 	expect_equal(di_get$author, "John Doe")
 
+	# Arbitrary (non-standard) info dictionary entries
+	di_set <- docinfo(author = "John Doe", ADBETest_MyKey = "My private information")
+	set_docinfo_pdftk(di_set, f1, f2)
+	di_get <- get_docinfo_pdftk(f2)[[1]]
+	expect_equal(di_get$author, "John Doe")
+	expect_equal(di_get$get_item("ADBETest_MyKey"), "My private information")
+
 	# Only partial update
 	f4 <- tempfile(fileext = ".pdf")
 	pdf(f4)

--- a/tests/testthat/test-docinfo.R
+++ b/tests/testthat/test-docinfo.R
@@ -57,6 +57,14 @@ test_that("docinfo_pdftk", {
 	expect_equal(di_get$author, "John Doe")
 	expect_equal(di_get$get_item("ADBETest_MyKey"), "My private information")
 
+	# Arbitrary key that is a prefix-collision with a standard key name
+	di_set <- docinfo(author = "John Doe")
+	di_set$set_item("AuthorX", "custom value")
+	set_docinfo_pdftk(di_set, f1, f2)
+	di_get <- get_docinfo_pdftk(f2)[[1]]
+	expect_equal(di_get$author, "John Doe")
+	expect_equal(di_get$get_item("AuthorX"), "custom value")
+
 	# Only partial update
 	f4 <- tempfile(fileext = ".pdf")
 	pdf(f4)
@@ -205,6 +213,19 @@ test_that("docinfo_exiftool", {
 	set_docinfo_exiftool(di_set, f1, f3)
 	di_get <- get_docinfo_exiftool(f3)[[1]]
 	expect_equal(di_get$get_item("WeirdKey"), "value with a 'quote' and a \\backslash")
+})
+
+test_that("docinfo() positional arguments", {
+	d <- docinfo("John Doe")
+	expect_equal(d$author, "John Doe")
+})
+
+test_that("docinfo() rejects invalid arbitrary keys", {
+	d <- docinfo()
+	d$set_item("My Key", "val")
+	expect_error(d$pdfmark())
+	expect_error(d$pdftk())
+	expect_error(d$exiftool_tags())
 })
 
 test_that("docinfo()", {

--- a/tests/testthat/test-docinfo.R
+++ b/tests/testthat/test-docinfo.R
@@ -17,6 +17,19 @@ test_that("get_docinfo_pdftools", {
 	skip_if_not_installed("pdftools")
 	expect_equal(get_docinfo_pdftools(f1)[[1]]$title, "R Graphics Output")
 })
+test_that("get_docinfo_pdftools arbitrary keys", {
+	skip_if_not_installed("pdftools")
+	skip_if_not(supports_pdftk())
+
+	f2 <- tempfile(fileext = ".pdf")
+	on.exit(unlink(f2), add = TRUE)
+	di_set <- docinfo(author = "John Doe", ADBETest_MyKey = "My private information")
+	set_docinfo_pdftk(di_set, f1, f2)
+
+	di_get <- get_docinfo_pdftools(f2)[[1]]
+	expect_equal(di_get$author, "John Doe")
+	expect_equal(di_get$get_item("ADBETest_MyKey"), "My private information")
+})
 test_that("docinfo_pdftk", {
 	skip_if_not(supports_pdftk())
 


### PR DESCRIPTION
- **feat(docinfo): Support arbitrary info dictionary entries (#7)**
- **feat(docinfo): Support arbitrary info dictionary entries in pdftk backend (#7)**
- **feat(docinfo): Support arbitrary info dictionary entries in gs backend (#7)**
- **feat(docinfo): Support arbitrary info dictionary entries in pdftools backend (#7)**
- **feat(docinfo): Support arbitrary info dictionary entries in exiftool backend (#7)**
- **docs: Add NEWS.md entry for arbitrary docinfo entry support (#7)**

closes #7
